### PR TITLE
Make chestplate timing configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ this includes only `generic_kill` (as used by `/kill`).
 Additional config options are set in `config/hexchanting.properties`. A [default configuration file](resources/hexchanting.properties)
 will be generated on launch and documentation can be found there.
 
+The chestplate trigger resolution order can be adjusted here, so that damage is applied before or after the chestplate
+hex is triggered. This is the default and historical behaviour. Adjust to taste.
+
 ## Notes
 
 - Cast on mine doesn't work in creative because it bypasses the tool entirely.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,22 @@ Casting. [Hex Book is here](https://arconyx.github.io/hexchanting/v/latest/main/
 
 ## Config
 
-The chestplate damage trigger ignores damage types listed in the tag `hexchanting:bypasses_armour_trigger`. By default this includes only `generic_kill` (as used by `/kill`).
+### Data pack
+The chestplate damage trigger ignores damage types listed in the tag `hexchanting:bypasses_armour_trigger`. By default,
+this includes only `generic_kill` (as used by `/kill`).
+
+### Config File
+Additional config options are set in `config/hexchanting.properties`. A [default configuration file](resources/hexchanting.properties)
+will be generated on launch and documentation can be found there.
 
 ## Notes
 
 - Cast on mine doesn't work in creative because it bypasses the tool entirely.
 - This is mostly made for personal use. Updates will be sporadic.
-- If you want to know what you can do with this, go read the license. I encourage you to tweak it, port it, borrow parts
-  or whatever else you want to do and share the results with the world.
+- If you want to know what you can do with this, go read the licence. I encourage you to tweak it, port it, borrow parts
+  or whatever else you want to do and share the results with the world. PRs welcome.
 - I am indebted to miyucomics and TechTastic, not that they know it, since their
   projects [Hexcellular](https://github.com/miyucomics/hexcellular/) and [HexWeb](https://github.com/TechTastic/HexWeb)
   were valuable reference points when I was getting started.
-- Also to everyone involved in making [HexDoc](https://github.com/hexdoc-dev/hexdoc) because they made documentation
-  easy.
+- Also to everyone involved in making [HexDoc](https://github.com/hexdoc-dev/hexdoc) because they made documentation easy.
 - And to everyone who has offered feedback in the Hex Casting Discord.

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.10
 fabric_kotlin_version=1.13.1+kotlin.2.1.10
 
 # Mod Properties
-mod_version=1.1.7
+mod_version=1.2.0
 maven_group=gay.thehivemind.hexchanting
 archives_base_name=hexchanting
 

--- a/src/main/java/gay/thehivemind/hexchanting/mixin/PlayerEntityMixin.java
+++ b/src/main/java/gay/thehivemind/hexchanting/mixin/PlayerEntityMixin.java
@@ -1,5 +1,8 @@
 package gay.thehivemind.hexchanting.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import gay.thehivemind.hexchanting.Hexchanting;
 import gay.thehivemind.hexchanting.HexchantingTags;
 import gay.thehivemind.hexchanting.items.armour.HexArmorItem;
 import net.minecraft.entity.EntityType;
@@ -11,6 +14,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -24,8 +28,57 @@ public abstract class PlayerEntityMixin extends LivingEntity {
     @Shadow
     public abstract Iterable<ItemStack> getArmorItems();
 
+    /**
+     * Invoke the chestplate hex at the start of damage processing, before armour or other modifiers are applied.
+     * Exactly one of this and {@link #triggerChestplateAfterDamage(PlayerEntity, float, Operation, DamageSource)} should trigger
+     * the chestplate for a given damage instance.
+     *
+     * @param source Damage source
+     * @param amount Damage taken, before processing
+     * @param ci     Mixin callback info
+     */
     @Inject(method = "applyDamage", at = @At(value = "HEAD"))
-    public void triggerArmor(DamageSource source, float amount, CallbackInfo ci) {
+    public void triggerChestplateBeforeDamage(DamageSource source, float amount, CallbackInfo ci) {
+        if (!Hexchanting.CONFIG.getApplyDamageBeforeChestplateTrigger()) {
+            triggerChestplate(source, amount);
+        }
+    }
+
+    /**
+     * Invoke the chestplate hex after damage has been applied to the player.
+     * Exactly one of this and {@link #triggerChestplateBeforeDamage(DamageSource, float, CallbackInfo)} should trigger
+     * the chestplate for a given damage instance.
+     *
+     * @param source Damage source
+     * @param newHealth New health when damage is applied
+     * @param original Wrapped operation
+     */
+    @WrapOperation(method = "applyDamage", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;setHealth(F)V",
+    shift = At.Shift.BY)
+    )
+    public void triggerChestplateAfterDamage(PlayerEntity instance, float newHealth, Operation<Void> original, DamageSource source) {
+        // The argument to setHealth is this.getHealth() - var7 where var7 is the damage taken
+        // So v = this.getHealth() - var7
+        // We rearrange the operation to extract the original damage, with armour, absorption and other such effect applied.
+        if (Hexchanting.CONFIG.getApplyDamageBeforeChestplateTrigger()) {
+            // the order of operations is very important here
+            float damage = this.getHealth() - newHealth;
+            original.call(instance, newHealth);
+            triggerChestplate(source, damage);
+        } else {
+            original.call(instance, newHealth);
+        }
+    }
+
+    /**
+     * Conditionally trigger the chestplate hex.
+     * The hex will not be triggered if the damage type is in the bypass tag or no hexchanting chestplate is found
+     *
+     * @param source The source of the damage
+     * @param amount The amount of damage taken
+     */
+    @Unique
+    private void triggerChestplate(DamageSource source, float amount) {
         if (this.getWorld().isClient() || this.isInvulnerableTo(source) || source.isIn(HexchantingTags.INSTANCE.getBYPASS_ARMOUR()))
             return;
         this.getArmorItems().forEach((ItemStack stack) -> {
@@ -34,4 +87,5 @@ public abstract class PlayerEntityMixin extends LivingEntity {
             }
         });
     }
+
 }

--- a/src/main/kotlin/gay/thehivemind/hexchanting/Hexchanting.kt
+++ b/src/main/kotlin/gay/thehivemind/hexchanting/Hexchanting.kt
@@ -1,19 +1,23 @@
 package gay.thehivemind.hexchanting
 
 import gay.thehivemind.hexchanting.casting.HexchantingPatterns
+import gay.thehivemind.hexchanting.config.HexchantingProperties
 import gay.thehivemind.hexchanting.items.HexchantingItems
 import net.fabricmc.api.ModInitializer
+import net.fabricmc.loader.api.FabricLoader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 object Hexchanting : ModInitializer {
     const val MOD_ID = "hexchanting"
     val LOGGER: Logger = LoggerFactory.getLogger(MOD_ID)
+    lateinit var CONFIG: HexchantingProperties
 
     override fun onInitialize() {
-        // This code runs as soon as Minecraft is in a mod-load-ready state.
-        // However, some things (like resources) may still be uninitialized.
-        // Proceed with mild caution.
+        this.CONFIG = HexchantingProperties.fromPath(
+            FabricLoader.getInstance().configDir.resolve("hexchanting.properties"), copyDefault = true)
+
+        // call to init some registries
         HexchantingItems
         HexchantingPatterns.init()
     }

--- a/src/main/kotlin/gay/thehivemind/hexchanting/config/HexchantingProperties.kt
+++ b/src/main/kotlin/gay/thehivemind/hexchanting/config/HexchantingProperties.kt
@@ -1,0 +1,115 @@
+package gay.thehivemind.hexchanting.config
+
+import gay.thehivemind.hexchanting.Hexchanting
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Properties
+
+/**
+ * This holds configuration for Hexchanting.
+ *
+ * It is static during runtime and assumed to be loaded at launch from a properties
+ * file using the associated [fromPath] function.
+ *
+ * Configuration values are set independently of the world save and so may change during the
+ * lifetime of the world (but not while it is running). Any issues that may occur from this should be documented
+ * in the configuration file.
+ *
+ * The default configuration file lives in the mod resources folder.
+ */
+data class HexchantingProperties(
+) {
+    companion object {
+        /**
+         * Load configuration from a Java `properties` file at the given path and translate it to our configuration
+         * object. If this file does not exist then the default configuration is used.
+         *
+         * @param copyDefault Whether to copy the default properties file to the given path if it doesn't already exist.
+         */
+        fun fromPath(path: Path, copyDefault: Boolean): HexchantingProperties {
+            val properties = loadPropertiesFile(path, copyDefault)
+
+            return when (val version = getOptionalLong(properties, "version", 1)) {
+                1L -> HexchantingProperties(
+                )
+                else -> throw RuntimeException("Invalid properties version $version. Accepted values: 1")
+            }
+        }
+
+        /**
+         * Handles the IO around loading a properties file. If loading fails an empty properties object is returned.
+         *
+         * Optionally creates a default properties file at the given path when no file is found.
+         */
+        private fun loadPropertiesFile(path: Path, copyDefault: Boolean): Properties {
+            val properties = Properties()
+
+            // If no properties file exists then copy one out of our resources
+            if (copyDefault && Files.notExists(path)) {
+                HexchantingProperties::class.java.classLoader.getResourceAsStream("hexchanting.properties")
+                    .use { defaultPropertiesStream ->
+                        if (defaultPropertiesStream == null) {
+                            Hexchanting.LOGGER.error("Unable to find default properties resource.")
+                        } else {
+                            try {
+                                Files.copy(defaultPropertiesStream, path)
+                                Hexchanting.LOGGER.info("Copied default properties file to $path")
+                            } catch (e: IOException) {
+                                // We might fail because the config folder is read only, for example
+                                // We don't want this to crash the application
+                                Hexchanting.LOGGER.error(
+                                    "Unable to copy default properties file to $path due to IOException",
+                                    e
+                                )
+                            } catch (e: FileAlreadyExistsException) {
+                                Hexchanting.LOGGER.warn(
+                                    "Unable to copy default properties to $path because file already exists",
+                                    e
+                                )
+                            } catch (e: Exception) {
+                                throw RuntimeException(
+                                    "Unable to copy default properties file to $path with unexpected cause",
+                                    e
+                                )
+                            }
+                        }
+
+                    }
+            }
+
+            try {
+                Files.newInputStream(path).use { propertiesStream ->
+                    properties.load(propertiesStream)
+                }
+            } catch (e: IOException) {
+                Hexchanting.LOGGER.warn("Unable to read config file due to IOException. Defaults will be used.", e)
+            }
+
+            return properties
+        }
+
+        /**
+         * Extract the value of the key from the properties object as a `Long` if present, else the default.
+         */
+        private fun getOptionalLong(properties: Properties, key: String, default: Long): Long {
+            val stringValue = properties.getProperty(key) ?: return default
+            val intValue = stringValue.toLongOrNull()
+                ?: throw RuntimeException("Unable to parse value $stringValue as a long integer for key $key in properties file")
+            return intValue
+        }
+
+        /**
+         * Extract the value of the key from the properties object as a `Boolean` if present, else the default.
+         *
+         * Only "true" and "false" are accepted (without quotes). Case-sensitive.
+         */
+        private fun getOptionalBoolean(properties: Properties, key: String, default: Boolean): Boolean {
+            val stringValue = properties.getProperty(key) ?: return default
+            val boolValue = stringValue.toBooleanStrictOrNull()
+                ?: throw RuntimeException("Unable to parse value $stringValue as a long integer for key $key in properties file")
+            return boolValue
+        }
+    }
+
+}

--- a/src/main/kotlin/gay/thehivemind/hexchanting/config/HexchantingProperties.kt
+++ b/src/main/kotlin/gay/thehivemind/hexchanting/config/HexchantingProperties.kt
@@ -19,6 +19,14 @@ import java.util.Properties
  * The default configuration file lives in the mod resources folder.
  */
 data class HexchantingProperties(
+    /**
+     * The amethyst chestplate triggers a hex when the player is damaged.
+     * When `true` the damage is applied to the player and then the hex is triggered. The damage value provided to the
+     * hex has armour, enchantments and absorption applied.
+     * When `false` the hex is triggered and then damage is applied. This permits tricks like applying absorption
+     * to negate the damage. Modifiers to the damage are not applied to the damage value sent to the hex.
+     */
+    val applyDamageBeforeChestplateTrigger: Boolean,
 ) {
     companion object {
         /**
@@ -32,6 +40,7 @@ data class HexchantingProperties(
 
             return when (val version = getOptionalLong(properties, "version", 1)) {
                 1L -> HexchantingProperties(
+                    applyDamageBeforeChestplateTrigger = getOptionalBoolean(properties, "applyDamageBeforeChestplateTrigger", false)
                 )
                 else -> throw RuntimeException("Invalid properties version $version. Accepted values: 1")
             }

--- a/src/main/resources/hexchanting.properties
+++ b/src/main/resources/hexchanting.properties
@@ -12,3 +12,15 @@
 # Current config version. Don't touch this and don't remove it.
 # Valid values: integer (default 1)
 version = 1
+
+# Control when the chestplate hex triggers during damage processing. This changes what hex designs are viable.
+# Changing this setting in an existing world is technically safe, but it will change behaviour that your hexes may
+# rely on!
+# When 'true' the chestplate trigger fires after damage is applied to the player.
+# The damage value provided to the hex has armour, enchantments and absorption applied.
+# If 'false' then the trigger fires before damage is applied to the player and does not
+# factor in any of the above modifiers. This is the behaviour in Hexchanting versions <1.2,
+# prior to this option being added.
+#
+# Valid values: boolean (default false)
+applyDamageBeforeChestplateTrigger = false

--- a/src/main/resources/hexchanting.properties
+++ b/src/main/resources/hexchanting.properties
@@ -1,0 +1,14 @@
+# Default config file for Hexchanting
+
+# If deleted this file will be regenerated on next launch.
+# If this file cannot be loaded then default values will be used.
+# If this file can be loaded but is invalid then loading will be halted and the game will crash.
+# This is probably an error with your config, but if you are sure it isn't please open a bug.
+# https://github.com/arconyx/hexchanting/issues
+
+# Notes
+# Boolean values accept 'true' or 'false' (no quotes, case-sensitive).
+
+# Current config version. Don't touch this and don't remove it.
+# Valid values: integer (default 1)
+version = 1


### PR DESCRIPTION
Currently the chestplate hex fires before the damage is applied. This allows for some fun behavior - forex #11. This can be fun but isn't desirable for some servers so this PR adds a configuration system then uses that system to add an option where the damage is applied before the hex fires.

This has the side effect of making the damage value passed to the player match the damage actually taken once armour, absorption and other effects are applied. This will resolve #17 for players who don't mind losing out on the other timing behaviour.