### PR TITLE
Limit paths that trigger CI on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 on:
   pull_request:
+    paths:
+      - 'libs/**'
+      - 'src.**'
+      - '*.gradle.kts'
+      - 'gradle**'
+      - '.github/workflows/build.yml'
   push:
     # in some ways I would prefer paths-ignore to be more
     # resilient against changes but this list is half the length

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -12,6 +12,14 @@ on:
       - 'uv.lock'
       - '.github/workflows/build_docs.yml'
   pull_request:
+    paths:
+      - 'doc/**'
+      - 'src/**'
+      - 'LICENSE'
+      - 'README.md'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/build_docs.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
We don't need to test builds for, e.g. changelog changes