### PR TITLE
Remove redundant operations when creating CastingImage

### DIFF
--- a/src/main/kotlin/gay/thehivemind/hexchanting/items/HexHolderEquipment.kt
+++ b/src/main/kotlin/gay/thehivemind/hexchanting/items/HexHolderEquipment.kt
@@ -95,13 +95,8 @@ interface HexHolderEquipment : HexImbuedItem {
         // TODO: but not for armour. investigate
         val context = PackagedToolCastEnv(player, Hand.MAIN_HAND, itemStack)
 
-        // Create empty casting image
-        var castingImage = CastingImage()
-        // prepare stack
-        val castingStack = castingImage.stack.toMutableList()
-        // We don't need to add the player to the stack, Mind's Reflection exists
-        castingStack.addAll(stack)
-        castingImage = castingImage.copy(stack = castingStack.toList())
+        // We have to use copy to create a casting image with a given stack because the constructor is private
+        val castingImage = CastingImage().copy(stack = stack)
 
         val vm = CastingVM(castingImage, context)
         val clientView = vm.queueExecuteAndWrapIotas(instructions, world)


### PR DESCRIPTION
The list to mutable list to list dance was a pointless remanent of old code. This simplifies it.

The use of copy to bypass a private constructor will be removed in Kotlin 2.5 but it works for now.